### PR TITLE
feat: Add Task Definition ARN Option

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 0 * * 2'
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,9 @@ inputs:
   run-task-started-by:
     description: "A name to use for the startedBy tag when running a task outside of a service. Will default to 'GitHub-Actions'."
     required: false
+  run-task-use-arn:
+    description: "If true will use an existing ARN passed in to the `task-definition`. Be careful when using this to ensure that the container already has been deployed somewhere."
+    required: false
   wait-for-task-stopped:
     description: 'Whether to wait for the task to stop when running it outside of a service. Will default to not wait.'
     required: false

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes) {
   if (securityGroupIds != "") {
     awsvpcConfiguration["securityGroups"] = securityGroupIds.split(',')
   }
-  
+
   const runTaskResponse = await ecs.runTask({
     startedBy: startedBy,
     cluster: clusterName,
@@ -373,6 +373,7 @@ async function run() {
     // Register the task definition or use passed in ARN
     let taskDefArn;
     if (shouldUseTaskARN) {
+      core.debug(`Using pre-existing task definition: ${taskDefinitionFile}`)
       taskDefArn = taskDefinitionFile;
     } else {
       core.debug('Registering the task definition');

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes) {
   if (securityGroupIds != "") {
     awsvpcConfiguration["securityGroups"] = securityGroupIds.split(',')
   }
-  console.log(awsvpcConfiguration)
+  
   const runTaskResponse = await ecs.runTask({
     startedBy: startedBy,
     cluster: clusterName,

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes) {
   if (securityGroupIds != "") {
     awsvpcConfiguration["securityGroups"] = securityGroupIds.split(',')
   }
-
+  console.log(awsvpcConfiguration)
   const runTaskResponse = await ecs.runTask({
     startedBy: startedBy,
     cluster: clusterName,
@@ -367,23 +367,31 @@ async function run() {
     const forceNewDeployInput = core.getInput('force-new-deployment', { required: false }) || 'false';
     const forceNewDeployment = forceNewDeployInput.toLowerCase() === 'true';
 
-    // Register the task definition
-    core.debug('Registering the task definition');
-    const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
-      taskDefinitionFile :
-      path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
-    const fileContents = fs.readFileSync(taskDefPath, 'utf8');
-    const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents))));
-    let registerResponse;
-    try {
-      registerResponse = await ecs.registerTaskDefinition(taskDefContents).promise();
-    } catch (error) {
-      core.setFailed("Failed to register task definition in ECS: " + error.message);
-      core.debug("Task definition contents:");
-      core.debug(JSON.stringify(taskDefContents, undefined, 4));
-      throw(error);
+    const shouldUseTaskARNInput = core.getInput('run-task-use-arn', { required: false }) || 'false';
+    const shouldUseTaskARN = shouldUseTaskARNInput.toLowerCase() === 'true';
+
+    // Register the task definition or use passed in ARN
+    let taskDefArn;
+    if (shouldUseTaskARN) {
+      taskDefArn = taskDefinitionFile;
+    } else {
+      core.debug('Registering the task definition');
+      const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
+        taskDefinitionFile :
+        path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
+      const fileContents = fs.readFileSync(taskDefPath, 'utf8');
+      const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents))));
+      let registerResponse;
+      try {
+        registerResponse = await ecs.registerTaskDefinition(taskDefContents).promise();
+      } catch (error) {
+        core.setFailed("Failed to register task definition in ECS: " + error.message);
+        core.debug("Task definition contents:");
+        core.debug(JSON.stringify(taskDefContents, undefined, 4));
+        throw(error);
+      }
+      taskDefArn = registerResponse.taskDefinition.taskDefinitionArn;
     }
-    const taskDefArn = registerResponse.taskDefinition.taskDefinitionArn;
     core.setOutput('task-definition-arn', taskDefArn);
 
     // Run the task outside of the service


### PR DESCRIPTION
Allows us to pass in a task definition ARN instead of a file. This way, an pre-existing and already deployed task definition can be used to run subsequent tasks.

Worth noting that if the task hasn't been registered yet then this can fail.
